### PR TITLE
Remove redondant monad type constraint

### DIFF
--- a/Startups/GameTypes.hs
+++ b/Startups/GameTypes.hs
@@ -70,8 +70,8 @@ _NonEmpty = prism' toList nonEmpty
 
 -- | This describe the capabilities needed to write the rules, when no
 -- interaction with the player is required.
-type NonInteractive m = (MonadState GameState m, Monad m, MonadError Message m, Functor m, Applicative m)
-type GameStateOnly m = (MonadState GameState m, Monad m, Functor m, Applicative m)
+type NonInteractive m = (MonadState GameState m, MonadError Message m, Functor m, Applicative m)
+type GameStateOnly m = (MonadState GameState m, Functor m, Applicative m)
 
 data CommunicationType = PlayerCom PlayerId Communication
                        | BroadcastCom Communication


### PR DESCRIPTION
Given the definition of `Monad m => MonadState s m` in mtl, I have been wondering about  the `Monad m` contraint in the `GameStateOnly` type.

Is it necessary ? The code still compiles (and test passes) if I remove it.
